### PR TITLE
Yoctol parser

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,32 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if tests don't hit abstract class
+    abc.
+    ABC
+    @abstractmethod
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+omit =
+    *__init__.py
+    *test*
+    .venv/*
+
+[html]
+directory = coverage_html_report

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.python.org/simple"
 name = "pypi"
 
 [packages]
+termcolor = "*"
 yoctol-argparse = {editable = true, path = "."}
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "93f74ef801e494f2aa428f2e5e3ed7857892898a62b1413e00edb563baa1f681"
+            "sha256": "f6c510f1660912b2820f2007f1ab143c6724d4e4b4c36519f2ea87fa42a48f67"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "termcolor": {
+            "hashes": [
+                "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
+        },
         "yoctol-argparse": {
             "editable": true,
             "path": "."

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -1,0 +1,33 @@
+import argparse
+
+from .formatters import format_choices
+
+
+class AppendIdValuePair(argparse.Action):
+
+    def __init__(self, id_choices, value_type, value_metavar, **kwargs):
+        super().__init__(nargs=2, **kwargs)
+        self.id_choices = id_choices
+        self.value_type = value_type
+        self.metavar = (format_choices(id_choices), value_metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        id_, value = values
+        try:
+            value = self.value_type(value)
+        except (TypeError, ValueError):
+            raise argparse.ArgumentError(
+                self,
+                f"invalid {self.value_type.__name__}: {value!r}",
+            )
+
+        if id_ not in self.id_choices:
+            raise argparse.ArgumentError(
+                self,
+                f"invalid choice: '{id_}' "
+                f"(choose from {', '.join(map(repr, self.id_choices))})",
+            )
+        if not getattr(namespace, self.dest, None):
+            setattr(namespace, self.dest, [])
+
+        getattr(namespace, self.dest).append((id_, value))

--- a/yoctol_argparse/formatters.py
+++ b/yoctol_argparse/formatters.py
@@ -1,0 +1,138 @@
+import argparse
+import re
+import shutil
+import termcolor
+
+
+class YoctolFormatter(argparse.ArgumentDefaultsHelpFormatter):
+
+    def __init__(self, prog):
+        super().__init__(prog, max_help_position=4, width=shutil.get_terminal_size()[0])
+
+    # Override: Change some format part to avoid [], () bracket broken
+    # https://github.com/python/cpython/blob/3.7/Lib/argparse.py#L391-L486
+    def _format_actions_usage(self, actions, groups):  # noqa: C901
+        # find group indices and identify actions in groups
+        group_actions = set()
+        inserts = {}
+        for group in groups:
+            try:
+                start = actions.index(group._group_actions[0])
+            except ValueError:
+                continue
+            else:
+                end = start + len(group._group_actions)
+                if actions[start:end] == group._group_actions:
+                    for action in group._group_actions:
+                        group_actions.add(action)
+                    if not group.required:
+                        if start in inserts:
+                            inserts[start] += ' ['
+                        else:
+                            inserts[start] = '['
+                        inserts[end] = ']'
+                    else:
+                        if start in inserts:
+                            inserts[start] += ' ('
+                        else:
+                            inserts[start] = '('
+                        inserts[end] = ')'
+                    for i in range(start + 1, end):
+                        inserts[i] = '|'
+
+        # collect all actions format strings
+        parts = []
+        for i, action in enumerate(actions):
+
+            # suppressed arguments are marked with None
+            # remove | separators for suppressed arguments
+            if action.help is argparse.SUPPRESS:
+                parts.append(None)
+                if inserts.get(i) == '|':
+                    inserts.pop(i)
+                elif inserts.get(i + 1) == '|':
+                    inserts.pop(i + 1)
+
+            # produce all arg strings
+            elif not action.option_strings:
+                default = self._get_default_metavar_for_positional(action)
+                part = self._format_args(action, default)
+
+                # if it's in a group, strip the outer []
+                if action in group_actions:
+                    if part[0] == '[' and part[-1] == ']':
+                        part = part[1:-1]
+
+                # add the action string to the list
+                parts.append(part)
+
+            # produce the first way to invoke the option in brackets
+            else:
+                option_string = action.option_strings[0]
+
+                # if the Optional doesn't take a value, format is:
+                #    -s or --long
+                if action.nargs == 0:
+                    part = '%s' % option_string
+
+                # if the Optional takes a value, format is:
+                #    -s ARGS or --long ARGS
+                else:
+                    default = self._get_default_metavar_for_optional(action)
+                    args_string = self._format_args(action, default)
+                    part = '%s %s' % (option_string, args_string)
+
+                # make it look optional if it's not required or in a group
+                if not action.required and action not in group_actions:
+                    part = '[%s]' % part
+
+                # add the action string to the list
+                parts.append(part)
+
+        # insert things at the necessary indices
+        for i in sorted(inserts, reverse=True):
+            parts[i:i] = [inserts[i]]
+
+        # join all the action items with spaces
+        text = ' '.join([item for item in parts if item is not None])
+
+        # clean up separators for mutually exclusive groups
+        open_ = r'[\[(]'
+        close = r'[\])]'
+        text = re.sub(r'(%s) ' % open_, r'\1', text)
+        text = re.sub(r' (%s)' % close, r'\1', text)
+        text = re.sub(r'%s *%s' % (open_, close), r'', text)
+        # remove one line from source code
+        text = text.strip()
+
+        # return the text
+        return text
+
+    def _metavar_formatter(self, action, default_metavar):
+        if action.metavar is not None:
+            result = action.metavar
+        elif action.choices is not None:
+            result = format_choices(action.choices)
+        else:
+            result = default_metavar
+
+        def format_func(tuple_size):
+            if isinstance(result, tuple):
+                return result
+            else:
+                return (result, ) * tuple_size
+        return format_func
+
+    def _get_default_metavar_for_optional(self, action):
+        return getattr(action.type, '__name__', repr(action.type))
+
+    def _get_default_metavar_for_positional(self, action):
+        return getattr(action.type, '__name__', repr(action.type))
+
+
+def format_choices(choices):
+    choice_strs = [
+        termcolor.colored(str(choice), attrs=['underline', 'dark'])
+        for choice in choices
+    ]
+    return f"{{{', '.join(choice_strs)}}}"

--- a/yoctol_argparse/formatters.py
+++ b/yoctol_argparse/formatters.py
@@ -9,9 +9,10 @@ class YoctolFormatter(argparse.ArgumentDefaultsHelpFormatter):
     def __init__(self, prog):
         super().__init__(prog, max_help_position=4, width=shutil.get_terminal_size()[0])
 
-    # Override: Change some format part to avoid [], () bracket broken
+    # HACK Override: Change some format part to avoid [], () bracket broken
     # https://github.com/python/cpython/blob/3.7/Lib/argparse.py#L391-L486
     def _format_actions_usage(self, actions, groups):  # noqa: C901
+        ########## COPY FROM SOURCE CODE ##########
         # find group indices and identify actions in groups
         group_actions = set()
         inserts = {}
@@ -102,7 +103,8 @@ class YoctolFormatter(argparse.ArgumentDefaultsHelpFormatter):
         text = re.sub(r'(%s) ' % open_, r'\1', text)
         text = re.sub(r' (%s)' % close, r'\1', text)
         text = re.sub(r'%s *%s' % (open_, close), r'', text)
-        # remove one line from source code
+        ########## END COPY FROM SOURCE CODE ##########
+        # remove L482 from source code to avoid [], () bracket broken
         text = text.strip()
 
         # return the text
@@ -112,6 +114,7 @@ class YoctolFormatter(argparse.ArgumentDefaultsHelpFormatter):
         if action.metavar is not None:
             result = action.metavar
         elif action.choices is not None:
+            # custom format for choices
             result = format_choices(action.choices)
         else:
             result = default_metavar
@@ -124,9 +127,11 @@ class YoctolFormatter(argparse.ArgumentDefaultsHelpFormatter):
         return format_func
 
     def _get_default_metavar_for_optional(self, action):
+        # add default if action.type has no '__name__' attribute
         return getattr(action.type, '__name__', repr(action.type))
 
     def _get_default_metavar_for_positional(self, action):
+        # add default if action.type has no '__name__' attribute
         return getattr(action.type, '__name__', repr(action.type))
 
 

--- a/yoctol_argparse/parser.py
+++ b/yoctol_argparse/parser.py
@@ -1,0 +1,36 @@
+import argparse
+
+from .formatters import YoctolFormatter
+
+
+class YoctolArgumentParser(argparse.ArgumentParser):
+
+    def __init__(
+            self,
+            prog=None,
+            usage=None,
+            description=None,
+            epilog=None,
+            parents=(),
+            formatter_class=YoctolFormatter,
+            prefix_chars='-',
+            fromfile_prefix_chars=None,
+            argument_default=None,
+            conflict_handler='error',
+            add_help=True,
+            allow_abbrev=True,
+        ):
+        super().__init__(
+            prog=prog,
+            usage=usage,
+            description=description,
+            epilog=epilog,
+            parents=parents,
+            formatter_class=formatter_class,
+            prefix_chars=prefix_chars,
+            fromfile_prefix_chars=fromfile_prefix_chars,
+            argument_default=argument_default,
+            conflict_handler=conflict_handler,
+            add_help=add_help,
+            allow_abbrev=allow_abbrev,
+        )

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import patch
+
+from ..actions import AppendIdValuePair
+from ..parser import YoctolArgumentParser
+
+
+@pytest.fixture(scope='module')
+def yoctol_parser():
+    parser = YoctolArgumentParser(prog='main.py')
+    parser.add_argument(
+        '--foo',
+        action=AppendIdValuePair,
+        id_choices=['a', 'b'],
+        value_metavar='boo',
+        value_type=int,
+    )
+    return parser
+
+
+def test_append(yoctol_parser):
+    with patch('sys.argv', 'main.py --foo a 1 --foo b 2 --foo a 3'.split(' ')):
+        args = yoctol_parser.parse_args()
+    assert args.foo == [('a', 1), ('b', 2), ('a', 3)]
+
+
+@pytest.mark.parametrize('invalid_arg', [
+    pytest.param('main.py --foo a', id='invalid_nargs'),
+    pytest.param('main.py --foo a 1 b', id='invalid_nargs'),
+    pytest.param('main.py --foo c 1', id='invalid_choice'),
+    pytest.param('main.py --foo a b', id='invalid_value'),
+])
+def test_raise_invalid_arg(yoctol_parser, invalid_arg):
+    argv = invalid_arg.split()
+    with patch('sys.argv', argv), pytest.raises(SystemExit) as exc_info:
+        yoctol_parser.parse_args()
+    assert exc_info.value.code == 2

--- a/yoctol_argparse/tests/test_fake.py
+++ b/yoctol_argparse/tests/test_fake.py
@@ -1,2 +1,0 @@
-def test_fake():
-    assert 1 == 1

--- a/yoctol_argparse/tests/test_parser.py
+++ b/yoctol_argparse/tests/test_parser.py
@@ -1,0 +1,23 @@
+import argparse
+import pytest
+from unittest.mock import patch
+
+from ..parser import YoctolArgumentParser
+
+
+@pytest.mark.parametrize('arg', [
+    'main.py -h',
+    'main.py --help',
+])
+def test_help_formatter(arg):
+    parser = YoctolArgumentParser()
+
+    parser.add_argument('x')
+    parser.add_argument('--y', help=argparse.SUPPRESS)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--foo', choices=['a', 'b', 'c'], action='append')
+    group.add_argument('--boo', choices=['a', 'b', 'c'], action='append')
+
+    with patch('sys.argv', arg.split()), pytest.raises(SystemExit) as exc_info:
+        parser.parse_args()
+    assert exc_info.value.code == 0

--- a/yoctol_argparse/tests/test_types.py
+++ b/yoctol_argparse/tests/test_types.py
@@ -1,0 +1,32 @@
+import pytest
+
+from ..types import int_in_range, float_in_range
+
+
+@pytest.mark.parametrize('func, x, valid', [
+    (int_in_range(0), '2', True),
+    (int_in_range(0), '0', True),
+    (int_in_range(), 'a', False),
+    (int_in_range(), '2.', False),
+])
+def test_int_in_range(func, x, valid):
+    if valid:
+        assert func(x) == int(x)
+    else:
+        with pytest.raises(ValueError):
+            func(x)
+
+
+@pytest.mark.parametrize('func, x, valid', [
+    (float_in_range(0), '2', True),
+    (float_in_range(0), '0', True),
+    (float_in_range(0, inclusive=False), '0', False),
+    (float_in_range(), 'a', False),
+    (float_in_range(), 'inf', False),
+])
+def test_float_in_range(func, x, valid):
+    if valid:
+        assert func(x) == float(x)
+    else:
+        with pytest.raises(ValueError):
+            func(x)

--- a/yoctol_argparse/tests/test_types.py
+++ b/yoctol_argparse/tests/test_types.py
@@ -1,11 +1,12 @@
 import pytest
 
-from ..types import int_in_range, float_in_range
+from ..types import int_in_range, float_in_range, path
 
 
 @pytest.mark.parametrize('func, x, valid', [
     (int_in_range(0), '2', True),
     (int_in_range(0), '0', True),
+    (int_in_range(2, 5), '6', False),
     (int_in_range(), 'a', False),
     (int_in_range(), '2.', False),
 ])
@@ -30,3 +31,21 @@ def test_float_in_range(func, x, valid):
     else:
         with pytest.raises(ValueError):
             func(x)
+
+
+def test_path():
+    assert path("A//B") == path("A/B/") == path("A/./B") == path("A/foo/../B") == "A/B"
+
+
+@pytest.mark.parametrize('func, expected_name', [
+    (int_in_range(0), 'nonnegative_int'),
+    (int_in_range(1), 'positive_int'),
+    (int_in_range(2), 'int∈[2, ∞)'),
+    (int_in_range(2, 5), 'int∈[2, 5]'),
+    (float_in_range(0.), 'nonnegative_float'),
+    (float_in_range(0., inclusive=False), 'positive_float'),
+    (float_in_range(1.), 'float∈[1.0, ∞)'),
+    (float_in_range(1., inclusive=False), 'float∈(1.0, ∞)'),
+])
+def test_name(func, expected_name):
+    assert func.__name__ == expected_name

--- a/yoctol_argparse/types.py
+++ b/yoctol_argparse/types.py
@@ -1,0 +1,59 @@
+import math
+import os
+
+
+def int_in_range(minval=-math.inf, maxval=math.inf):
+
+    def func(x):
+        return _validate_in_range(int(x), minval, maxval, inclusive=True)
+
+    if (minval, maxval) == (1, math.inf):
+        func.__name__ = 'positive_int'
+    elif (minval, maxval) == (0, math.inf):
+        func.__name__ = 'nonnegative_int'
+    else:
+        func.__name__ = f'int∈{_repr_inteval(minval, maxval, inclusive=True)}'
+    return func
+
+
+def float_in_range(minval=-math.inf, maxval=math.inf, inclusive=True):
+
+    def func(x):
+        return _validate_in_range(float(x), minval, maxval, inclusive=inclusive)
+
+    if (minval, maxval, inclusive) == (0., math.inf, False):
+        func.__name__ = 'positive_float'
+    elif (minval, maxval, inclusive) == (0., math.inf, True):
+        func.__name__ = 'nonnegative_float'
+    else:
+        func.__name__ = f'float∈{_repr_inteval(minval, maxval, inclusive)}'
+    return func
+
+
+def _validate_in_range(x, minval, maxval, inclusive):
+    if math.isinf(x):
+        raise ValueError
+    if inclusive:
+        if not (minval <= x <= maxval):
+            raise ValueError
+    elif not (minval < x < maxval):
+        raise ValueError
+    return x
+
+
+def _repr_inteval(minval, maxval, inclusive):
+
+    def _math_repr(x):
+        if x == -math.inf:
+            return '-∞'
+        if x == math.inf:
+            return '∞'
+        return repr(x)
+
+    left_bracket = '[' if (inclusive and not math.isinf(minval)) else '('
+    right_bracket = ']' if (inclusive and not math.isinf(maxval)) else ')'
+    return f"{left_bracket}{_math_repr(minval)}, {_math_repr(maxval)}{right_bracket}"
+
+
+def path(x):
+    return os.path.normpath(x)


### PR DESCRIPTION
有以下功能：

1. --help 時，choices usage 會用 termcolor underline
2. 新增 AppendIdValuePair action，支援以下用法，並會在 id, value 分別套用 choice 和 type
```python
parser.add_argument(
    '--task',
    action=AppendIdValuePair,
    id_choices=['a', 'b'],
    value_type=float,
    value_metavar='LEARNING_RATE',
)
parser.parse_args('--task a 0.01 --task b 0.01'.split())
### [('a', 0.01), ('b', 0.01)]
parser.parse_args('--task a b'.split())  # invalid type
parser.parse_args('--task a'.split())  # invalid nargs
parser.parse_args('--task c 0.1'.split())  # invalid choice
```
3. 新增 path, float_in_range, int_in_range 等等 type，並會幫忙檢查，例如：
```python
parser.add_arguement(
    '--xxx_prob',
    type=float_in_range(0., 1.),
)
```

help 的測試，只是套套各種可能看他會不會錯而已，沒有檢查格式
衝到 87% coverage