### PR TITLE
long_description_content_type="text/markdown"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     version='0.1.0',
     description='Argument Parser create by Yoctol',
     long_description=long_description,
+    long_description_content_type="text/markdown",
     python_requires='>=3.6',
     packages=find_packages(),
     author='noobOriented',


### PR DESCRIPTION
我們的 README.md 無法轉成 reStructuredText

uttut 是用 pydandoc 這個套件轉的：https://github.com/Yoctol/uttut/blob/master/setup.py#L81-L86

但似乎設定 long_description_content_type="text/markdown" 就可以了
ref: https://zhuanlan.zhihu.com/p/34853707