### PR TITLE
Params parser

### DIFF
--- a/examples/id_kwargs.py
+++ b/examples/id_kwargs.py
@@ -28,9 +28,9 @@ parser.parse_args('--exercise bench weight=10&weight=40'.split())  # duplicated 
 
 
 parser.parse_args(['--help'])
-# usage: id_value_pair.py [-h] [--exercise {squat, bench, deadlift} KWARGS_STRING]
+# usage: id_value_pair.py [-h] [--exercise {squat, bench, deadlift} KEY1=VAL1&KEY2=VAL2...]
 
 # optional arguments:
 #   -h, --help
 #     show this help message and exit
-#   --exercise {squat, bench, deadlift} KWARGS_STRING
+#   --exercise {squat, bench, deadlift} KEY1=VAL1&KEY2=VAL2...

--- a/examples/id_kwargs.py
+++ b/examples/id_kwargs.py
@@ -1,0 +1,34 @@
+from yoctol_argparse import (
+    YoctolArgumentParser,
+    StoreIdKwargs,
+)
+
+parser = YoctolArgumentParser()
+
+parser.add_argument(
+    '--exercise',
+    action=StoreIdKwargs,
+    id_choices=['squat', 'bench', 'deadlift'],
+    split_token='&',
+    use_bool_abbreviation=True,
+    help='(exercise_type, kwargs_string)',
+)
+
+parser.parse_args('--exercise bench weight=70.0&reps=4&sets=4'.split())
+# = Namespace(exercise=('bench', {'weight': 70.0, 'reps': 4, 'sets': 4}))
+parser.parse_args('--exercise squat weight=90.0&reps=4&sets=4&use_belt'.split())
+# = Namespace(exercise=('squat', {'weight': 90.0, 'reps': 4, 'sets': 4, 'use_belt': True}))
+
+parser.parse_args('--exercise bench'.split())     # invalid nargs != 2
+parser.parse_args('--exercise smith_machine weight=10'.split())  # invalid id isn't in choices
+parser.parse_args('--exercise bench weight=max'.split())   # invalid value isn't int, float or bool
+parser.parse_args('--exercise bench weight=10&weight=40'.split())  # duplicated key
+
+
+parser.parse_args(['--help'])
+# usage: id_value_pair.py [-h] [--exercise {squat, bench, deadlift} KWARGS_STRING]
+
+# optional arguments:
+#   -h, --help
+#     show this help message and exit
+#   --exercise {squat, bench, deadlift} KWARGS_STRING

--- a/examples/id_kwargs.py
+++ b/examples/id_kwargs.py
@@ -14,6 +14,8 @@ parser.add_argument(
     help='(exercise_type, kwargs_string)',
 )
 
+parser.parse_args('--exercise bench'.split())
+# = Namespace(exercise=('bench', {}))
 parser.parse_args('--exercise bench weight=70.0&reps=4&sets=4'.split())
 # = Namespace(exercise=('bench', {'weight': 70.0, 'reps': 4, 'sets': 4}))
 parser.parse_args('--exercise squat weight=90.0&reps=4&sets=4&use_belt'.split())
@@ -21,7 +23,8 @@ parser.parse_args('--exercise squat weight=90.0&reps=4&sets=4&use_belt'.split())
 parser.parse_args('--exercise deadlift trainer="Daniel"&style="sumo"'.split())
 # = Namespace(exercise=('deadlift', {'trainer': 'Daniel', 'style': 'sumo'}))
 
-parser.parse_args('--exercise bench'.split())     # invalid nargs != 2
+parser.parse_args('--exercise'.split())     # invalid nargs = 0
+parser.parse_args('--exercise bench squat deadlift'.split())     # invalid nargs > 2
 parser.parse_args('--exercise smith_machine weight=10'.split())  # invalid id isn't in choices
 parser.parse_args('--exercise bench weight=max'.split())   # invalid value isn't int, float or bool
 parser.parse_args('--exercise bench weight=10&weight=40'.split())  # duplicated key

--- a/examples/id_kwargs.py
+++ b/examples/id_kwargs.py
@@ -18,6 +18,8 @@ parser.parse_args('--exercise bench weight=70.0&reps=4&sets=4'.split())
 # = Namespace(exercise=('bench', {'weight': 70.0, 'reps': 4, 'sets': 4}))
 parser.parse_args('--exercise squat weight=90.0&reps=4&sets=4&use_belt'.split())
 # = Namespace(exercise=('squat', {'weight': 90.0, 'reps': 4, 'sets': 4, 'use_belt': True}))
+parser.parse_args('--exercise deadlift trainer="Daniel"&style="sumo"'.split())
+# = Namespace(exercise=('deadlift', {'trainer': 'Daniel', 'style': 'sumo'}))
 
 parser.parse_args('--exercise bench'.split())     # invalid nargs != 2
 parser.parse_args('--exercise smith_machine weight=10'.split())  # invalid id isn't in choices

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 
 setup(
     name='yoctol-argparse',
-    version='0.1.0',
+    version='0.2.0',
     description='Argument Parser create by Yoctol',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/yoctol_argparse/__init__.py
+++ b/yoctol_argparse/__init__.py
@@ -1,4 +1,4 @@
-from .actions import AppendIdValuePair
+from .actions import AppendIdValuePair, StoreIdKwargs
 from .formatters import YoctolFormatter
 from .parser import YoctolArgumentParser
 from .types import (

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -58,10 +58,15 @@ class StoreIdKwargs(argparse.Action):
             )
         try:
             kwargs = self._process_kwargs_string(kwarg_string)
-        except (TypeError, ValueError):
+        except ValueError:
             raise argparse.ArgumentError(
                 self,
                 f"invalid kwargs: {kwarg_string!r}",
+            )
+        except NameError:
+            raise argparse.ArgumentError(
+                self,
+                "value should be int, float or boolean."
             )
 
         setattr(namespace, self.dest, (id_, kwargs))

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -31,3 +31,55 @@ class AppendIdValuePair(argparse.Action):
             setattr(namespace, self.dest, [])
 
         getattr(namespace, self.dest).append((id_, value))
+
+
+class StoreIdKwargs(argparse.Action):
+
+    def __init__(
+            self,
+            id_choices,
+            split_token='&',
+            use_boolean_abbreviation=True,
+            **kwargs,
+        ):
+        super().__init__(nargs=2, **kwargs)
+        self.id_choices = id_choices
+        self.split_token = split_token
+        self.use_boolean_abbreviation = use_boolean_abbreviation
+        self.metavar = (format_choices(id_choices), 'KWARGS STRING')
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        id_, kwarg_string = values
+        if id_ not in self.id_choices:
+            raise argparse.ArgumentError(
+                self,
+                f"invalid choice: '{id_}' "
+                f"(choose from {', '.join(map(repr, self.id_choices))})",
+            )
+        try:
+            kwargs = self._process_kwargs_string(kwarg_string)
+        except (TypeError, ValueError):
+            raise argparse.ArgumentError(
+                self,
+                f"invalid kwargs: {kwarg_string!r}",
+            )
+
+        setattr(namespace, self.dest, (id_, kwargs))
+
+    def _process_kwargs_string(self, kwarg_string):
+        kwargs = {}
+        kvs = kwarg_string.split(self.split_token)
+        for kv in kvs:
+            if '=' in kv:
+                key, val = kv.split('=')
+                val = eval(val)
+            elif self.use_boolean_abbreviation:
+                key, val = kv, True
+            else:
+                raise ValueError
+
+            if key in kwargs:
+                raise ValueError
+            kwargs[key] = val
+
+        return kwargs

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -39,14 +39,14 @@ class StoreIdKwargs(argparse.Action):
             self,
             id_choices,
             split_token='&',
-            use_boolean_abbreviation=True,
+            use_bool_abbreviation=True,
             **kwargs,
         ):
         super().__init__(nargs=2, **kwargs)
         self.id_choices = id_choices
         self.split_token = split_token
-        self.use_boolean_abbreviation = use_boolean_abbreviation
-        self.metavar = (format_choices(id_choices), 'KWARGS STRING')
+        self.use_bool_abbreviation = use_bool_abbreviation
+        self.metavar = (format_choices(id_choices), 'KWARGS_STRING')
 
     def __call__(self, parser, namespace, values, option_string=None):
         id_, kwarg_string = values
@@ -66,7 +66,7 @@ class StoreIdKwargs(argparse.Action):
         except NameError:
             raise argparse.ArgumentError(
                 self,
-                "value should be int, float or boolean."
+                "value should be int, float or boolean.",
             )
 
         setattr(namespace, self.dest, (id_, kwargs))
@@ -78,7 +78,7 @@ class StoreIdKwargs(argparse.Action):
             if '=' in kv:
                 key, val = kv.split('=')
                 val = eval(val)
-            elif self.use_boolean_abbreviation:
+            elif self.use_bool_abbreviation:
                 key, val = kv, True
             else:
                 raise ValueError

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -46,7 +46,7 @@ class StoreIdKwargs(argparse.Action):
         self.id_choices = id_choices
         self.split_token = split_token
         self.use_bool_abbreviation = use_bool_abbreviation
-        self.metavar = (format_choices(id_choices), 'KWARGS_STRING')
+        self.metavar = (format_choices(id_choices), f'KEY1=VALUE1{split_token}KEY2=VALUE2...')
 
     def __call__(self, parser, namespace, values, option_string=None):
         id_, kwarg_string = values

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -66,7 +66,7 @@ class StoreIdKwargs(argparse.Action):
         except NameError:
             raise argparse.ArgumentError(
                 self,
-                "value should be int, float or boolean.",
+                "value should be built-in types.",
             )
 
         setattr(namespace, self.dest, (id_, kwargs))
@@ -77,7 +77,7 @@ class StoreIdKwargs(argparse.Action):
         for kv in kvs:
             if '=' in kv:
                 key, val = kv.split('=')
-                val = eval(val)
+                val = eval(val, {}, {})  # disallow local, global vars
             elif self.use_bool_abbreviation:
                 key, val = kv, True
             else:

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -46,7 +46,7 @@ class TestStoreIdKwargs:
             '--foo',
             action=StoreIdKwargs,
             id_choices=['a', 'b'],
-            use_boolean_abbreviation=True,
+            use_bool_abbreviation=True,
         )
         return parser
 

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -1,37 +1,71 @@
 import pytest
 from unittest.mock import patch
 
-from ..actions import AppendIdValuePair
+from ..actions import AppendIdValuePair, StoreIdKwargs
 from ..parser import YoctolArgumentParser
 
 
-@pytest.fixture(scope='module')
-def yoctol_parser():
-    parser = YoctolArgumentParser(prog='main.py')
-    parser.add_argument(
-        '--foo',
-        action=AppendIdValuePair,
-        id_choices=['a', 'b'],
-        value_metavar='boo',
-        value_type=int,
-    )
-    return parser
+class TestAppendIdValuePair:
+
+    @pytest.fixture(scope='class')
+    def yoctol_parser(self):
+        parser = YoctolArgumentParser(prog='main.py')
+        parser.add_argument(
+            '--foo',
+            action=AppendIdValuePair,
+            id_choices=['a', 'b'],
+            value_metavar='boo',
+            value_type=int,
+        )
+        return parser
+
+    def test_append(self, yoctol_parser):
+        with patch('sys.argv', 'main.py --foo a 1 --foo b 2 --foo a 3'.split(' ')):
+            args = yoctol_parser.parse_args()
+        assert args.foo == [('a', 1), ('b', 2), ('a', 3)]
+
+    @pytest.mark.parametrize('invalid_arg', [
+        pytest.param('main.py --foo a', id='invalid_nargs'),
+        pytest.param('main.py --foo a 1 b', id='invalid_nargs'),
+        pytest.param('main.py --foo c 1', id='invalid_choice'),
+        pytest.param('main.py --foo a b', id='invalid_value'),
+    ])
+    def test_raise_invalid_arg(self, yoctol_parser, invalid_arg):
+        argv = invalid_arg.split()
+        with patch('sys.argv', argv), pytest.raises(SystemExit) as exc_info:
+            yoctol_parser.parse_args()
+        assert exc_info.value.code == 2
 
 
-def test_append(yoctol_parser):
-    with patch('sys.argv', 'main.py --foo a 1 --foo b 2 --foo a 3'.split(' ')):
-        args = yoctol_parser.parse_args()
-    assert args.foo == [('a', 1), ('b', 2), ('a', 3)]
+class TestStoreIdKwargs:
 
+    @pytest.fixture(scope='class')
+    def yoctol_parser(self):
+        parser = YoctolArgumentParser(prog='main.py')
+        parser.add_argument(
+            '--foo',
+            action=StoreIdKwargs,
+            id_choices=['a', 'b'],
+            use_boolean_abbreviation=True,
+        )
+        return parser
 
-@pytest.mark.parametrize('invalid_arg', [
-    pytest.param('main.py --foo a', id='invalid_nargs'),
-    pytest.param('main.py --foo a 1 b', id='invalid_nargs'),
-    pytest.param('main.py --foo c 1', id='invalid_choice'),
-    pytest.param('main.py --foo a b', id='invalid_value'),
-])
-def test_raise_invalid_arg(yoctol_parser, invalid_arg):
-    argv = invalid_arg.split()
-    with patch('sys.argv', argv), pytest.raises(SystemExit) as exc_info:
-        yoctol_parser.parse_args()
-    assert exc_info.value.code == 2
+    def test_store(self, yoctol_parser):
+        with patch('sys.argv', 'main.py --foo a x=1&y=2&z'.split(' ')):
+            args = yoctol_parser.parse_args()
+        assert args.foo == ('a', {'x': 1, 'y': 2, 'z': True})
+
+    @pytest.mark.parametrize('invalid_arg', [
+        pytest.param('main.py --foo a', id='invalid_nargs'),
+        pytest.param('main.py --foo a 1 b', id='invalid_nargs'),
+        pytest.param('main.py --foo c 1', id='invalid_choice'),
+        pytest.param('main.py --foo a x=1=y', id='invalid_format_='),
+        pytest.param('main.py --foo a x=1,y=y', id='invalid_format_split'),
+        pytest.param('main.py --foo a x=1&y=y', id='invalid_value'),
+        pytest.param('main.py --foo a x=1&x=2', id='duplicated_key'),
+    ])
+    def test_raise_invalid_arg(self, yoctol_parser, invalid_arg):
+        argv = invalid_arg.split()
+        with patch('sys.argv', argv), pytest.raises(SystemExit) as exc_info:
+            yoctol_parser.parse_args()
+        assert exc_info.value.code == 2

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -50,14 +50,18 @@ class TestStoreIdKwargs:
         )
         return parser
 
-    def test_store(self, yoctol_parser):
-        with patch('sys.argv', 'main.py --foo a x=1&y=2&z&w="w"'.split(' ')):
+    @pytest.mark.parametrize('arg_string, expected_output', [
+        ('main.py --foo a', ('a', {})),
+        ('main.py --foo a x=1&y=False&z&w="w"', ('a', {'x': 1, 'y': False, 'z': True, 'w': 'w'})),
+    ])
+    def test_store(self, yoctol_parser, arg_string, expected_output):
+        with patch('sys.argv', arg_string.split(' ')):
             args = yoctol_parser.parse_args()
-        assert args.foo == ('a', {'x': 1, 'y': 2, 'z': True, 'w': 'w'})
+        assert args.foo == expected_output
 
     @pytest.mark.parametrize('invalid_arg', [
-        pytest.param('main.py --foo a', id='invalid_nargs'),
-        pytest.param('main.py --foo a 1 b', id='invalid_nargs'),
+        pytest.param('main.py --foo', id='nargs<1'),
+        pytest.param('main.py --foo a 1 b', id='nargs>2'),
         pytest.param('main.py --foo c 1', id='invalid_choice'),
         pytest.param('main.py --foo a x=1=y', id='invalid_format_='),
         pytest.param('main.py --foo a x=1,y=y', id='invalid_format_split'),

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -51,9 +51,9 @@ class TestStoreIdKwargs:
         return parser
 
     def test_store(self, yoctol_parser):
-        with patch('sys.argv', 'main.py --foo a x=1&y=2&z'.split(' ')):
+        with patch('sys.argv', 'main.py --foo a x=1&y=2&z&w="w"'.split(' ')):
             args = yoctol_parser.parse_args()
-        assert args.foo == ('a', {'x': 1, 'y': 2, 'z': True})
+        assert args.foo == ('a', {'x': 1, 'y': 2, 'z': True, 'w': 'w'})
 
     @pytest.mark.parametrize('invalid_arg', [
         pytest.param('main.py --foo a', id='invalid_nargs'),


### PR DESCRIPTION
實作 StoreIdParams Action 支援以下用法

`--optimizer adam beta1=0.9&beta2=0.999`

需要兩個 args, 第一個為種類
第二個會辨識 split_token (預設 &) 和 = ，parse 成 dictionary

若 use_bool_abbreviation=True 則會把沒有 = 的當成 True
例如：
`--optimizer adam beta1=0.9&beta2=0.999&use_lookahead`

詳情請看 examples/id_kwargs.py