### PR TITLE
Fix kwargs parser

### DIFF
--- a/examples/id_kwargs.py
+++ b/examples/id_kwargs.py
@@ -9,31 +9,31 @@ parser.add_argument(
     '--exercise',
     action=StoreIdKwargs,
     id_choices=['squat', 'bench', 'deadlift'],
-    split_token='&',
+    split_token=',',
     use_bool_abbreviation=True,
     help='(exercise_type, kwargs_string)',
 )
 
 parser.parse_args('--exercise bench'.split())
 # = Namespace(exercise=('bench', {}))
-parser.parse_args('--exercise bench weight=70.0&reps=4&sets=4'.split())
+parser.parse_args('--exercise bench weight=70.0,reps=4,sets=4'.split())
 # = Namespace(exercise=('bench', {'weight': 70.0, 'reps': 4, 'sets': 4}))
-parser.parse_args('--exercise squat weight=90.0&reps=4&sets=4&use_belt'.split())
+parser.parse_args('--exercise squat weight=90.0,reps=4,sets=4,use_belt'.split())
 # = Namespace(exercise=('squat', {'weight': 90.0, 'reps': 4, 'sets': 4, 'use_belt': True}))
-parser.parse_args('--exercise deadlift trainer="Daniel"&style="sumo"'.split())
+parser.parse_args('--exercise deadlift trainer="Daniel",style="sumo"'.split())
 # = Namespace(exercise=('deadlift', {'trainer': 'Daniel', 'style': 'sumo'}))
 
-# parser.parse_args('--exercise'.split())     # invalid nargs = 0
-# parser.parse_args('--exercise bench squat deadlift'.split())     # invalid nargs > 2
-# parser.parse_args('--exercise smith_machine weight=10'.split())  # invalid id isn't in choices
-# parser.parse_args('--exercise bench weight=max'.split())   # invalid value isn't int, float or bool
-# parser.parse_args('--exercise bench weight=10&weight=40'.split())  # duplicated key
+parser.parse_args('--exercise'.split())     # invalid nargs = 0
+parser.parse_args('--exercise bench squat deadlift'.split())     # invalid nargs > 2
+parser.parse_args('--exercise smith_machine weight=10'.split())  # invalid id isn't in choices
+parser.parse_args('--exercise bench weight=max'.split())   # invalid value isn't int, float or bool
+parser.parse_args('--exercise bench weight=10,weight=40'.split())  # duplicated key
 
 
 parser.parse_args(['--help'])
-# usage: id_value_pair.py [-h] [--exercise {squat, bench, deadlift} KEY1=VAL1&KEY2=VAL2 ...]
+# usage: id_value_pair.py [-h] [--exercise {squat, bench, deadlift} KEY1=VAL1,KEY2=VAL2 ...]
 
 # optional arguments:
 #   -h, --help
 #     show this help message and exit
-#   --exercise {squat, bench, deadlift} KEY1=VAL1&KEY2=VAL2 ...
+#   --exercise {squat, bench, deadlift} KEY1=VAL1,KEY2=VAL2 ...

--- a/examples/id_kwargs.py
+++ b/examples/id_kwargs.py
@@ -23,17 +23,17 @@ parser.parse_args('--exercise squat weight=90.0&reps=4&sets=4&use_belt'.split())
 parser.parse_args('--exercise deadlift trainer="Daniel"&style="sumo"'.split())
 # = Namespace(exercise=('deadlift', {'trainer': 'Daniel', 'style': 'sumo'}))
 
-parser.parse_args('--exercise'.split())     # invalid nargs = 0
-parser.parse_args('--exercise bench squat deadlift'.split())     # invalid nargs > 2
-parser.parse_args('--exercise smith_machine weight=10'.split())  # invalid id isn't in choices
-parser.parse_args('--exercise bench weight=max'.split())   # invalid value isn't int, float or bool
-parser.parse_args('--exercise bench weight=10&weight=40'.split())  # duplicated key
+# parser.parse_args('--exercise'.split())     # invalid nargs = 0
+# parser.parse_args('--exercise bench squat deadlift'.split())     # invalid nargs > 2
+# parser.parse_args('--exercise smith_machine weight=10'.split())  # invalid id isn't in choices
+# parser.parse_args('--exercise bench weight=max'.split())   # invalid value isn't int, float or bool
+# parser.parse_args('--exercise bench weight=10&weight=40'.split())  # duplicated key
 
 
 parser.parse_args(['--help'])
-# usage: id_value_pair.py [-h] [--exercise {squat, bench, deadlift} KEY1=VAL1&KEY2=VAL2...]
+# usage: id_value_pair.py [-h] [--exercise {squat, bench, deadlift} KEY1=VAL1&KEY2=VAL2 ...]
 
 # optional arguments:
 #   -h, --help
 #     show this help message and exit
-#   --exercise {squat, bench, deadlift} KEY1=VAL1&KEY2=VAL2...
+#   --exercise {squat, bench, deadlift} KEY1=VAL1&KEY2=VAL2 ...

--- a/yoctol_argparse/__version__.py
+++ b/yoctol_argparse/__version__.py
@@ -1,4 +1,4 @@
 __title__ = 'yoctol-argparse'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __description__ = 'Argument Parser created by Yoctol'
 __author__ = 'noobOriented'

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -46,7 +46,7 @@ class StoreIdKwargs(argparse.Action):
         self.id_choices = id_choices
         self.split_token = split_token
         self.use_bool_abbreviation = use_bool_abbreviation
-        self.metavar = (format_choices(id_choices), f'KEY1=VALUE1{split_token}KEY2=VALUE2...')
+        self.metavar = (format_choices(id_choices), f'KEY1=VALUE1{split_token}KEY2=VALUE2')
 
     def __call__(self, parser, namespace, values, option_string=None):
         if len(values) == 2:

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -38,7 +38,7 @@ class StoreIdKwargs(argparse.Action):
     def __init__(
             self,
             id_choices,
-            split_token='&',
+            split_token=',',
             use_bool_abbreviation=True,
             **kwargs,
         ):

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -52,7 +52,7 @@ class TestStoreIdKwargs:
 
     @pytest.mark.parametrize('arg_string, expected_output', [
         ('main.py --foo a', ('a', {})),
-        ('main.py --foo a x=1&y=False&z&w="w"', ('a', {'x': 1, 'y': False, 'z': True, 'w': 'w'})),
+        ('main.py --foo a x=1,y=False,z,w="w"', ('a', {'x': 1, 'y': False, 'z': True, 'w': 'w'})),
     ])
     def test_store(self, yoctol_parser, arg_string, expected_output):
         with patch('sys.argv', arg_string.split(' ')):
@@ -64,9 +64,9 @@ class TestStoreIdKwargs:
         pytest.param('main.py --foo a 1 b', id='nargs>2'),
         pytest.param('main.py --foo c 1', id='invalid_choice'),
         pytest.param('main.py --foo a x=1=y', id='invalid_format_='),
-        pytest.param('main.py --foo a x=1,y=y', id='invalid_format_split'),
-        pytest.param('main.py --foo a x=1&y=y', id='invalid_value'),
-        pytest.param('main.py --foo a x=1&x=2', id='duplicated_key'),
+        pytest.param('main.py --foo a x=1+y=y', id='invalid_format_split'),
+        pytest.param('main.py --foo a x=1,y=y', id='invalid_value'),
+        pytest.param('main.py --foo a x=1,x=2', id='duplicated_key'),
     ])
     def test_raise_invalid_arg(self, yoctol_parser, invalid_arg):
         argv = invalid_arg.split()


### PR DESCRIPTION
之前的 default split_token 是 `&`
是 unix 的保留字
改 `,`