### PR TITLE
Fix kwargs parser

### DIFF
--- a/examples/id_kwargs.py
+++ b/examples/id_kwargs.py
@@ -20,13 +20,12 @@ parser.parse_args('--exercise bench weight=70.0,reps=4,sets=4'.split())
 # = Namespace(exercise=('bench', {'weight': 70.0, 'reps': 4, 'sets': 4}))
 parser.parse_args('--exercise squat weight=90.0,reps=4,sets=4,use_belt'.split())
 # = Namespace(exercise=('squat', {'weight': 90.0, 'reps': 4, 'sets': 4, 'use_belt': True}))
-parser.parse_args('--exercise deadlift trainer="Daniel",style="sumo"'.split())
+parser.parse_args('--exercise deadlift trainer=Daniel,style=sumo'.split())
 # = Namespace(exercise=('deadlift', {'trainer': 'Daniel', 'style': 'sumo'}))
 
 parser.parse_args('--exercise'.split())     # invalid nargs = 0
 parser.parse_args('--exercise bench squat deadlift'.split())     # invalid nargs > 2
 parser.parse_args('--exercise smith_machine weight=10'.split())  # invalid id isn't in choices
-parser.parse_args('--exercise bench weight=max'.split())   # invalid value isn't int, float or bool
 parser.parse_args('--exercise bench weight=10,weight=40'.split())  # duplicated key
 
 

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -1,4 +1,5 @@
 import argparse
+from collections import namedtuple
 
 from .formatters import format_choices
 
@@ -34,6 +35,8 @@ class AppendIdValuePair(argparse.Action):
 
 
 class StoreIdKwargs(argparse.Action):
+
+    IdKwargsPair = namedtuple('IdKwargsPair', ['id', 'kwargs'])
 
     def __init__(
             self,
@@ -80,7 +83,7 @@ class StoreIdKwargs(argparse.Action):
                 f"(choose from {', '.join(map(repr, self.id_choices))})",
             )
 
-        setattr(namespace, self.dest, (id_, kwargs))
+        setattr(namespace, self.dest, self.IdKwargsPair(id_, kwargs))
 
     def _process_kwargs_string(self, kwarg_string):
         kwargs = {}

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -1,4 +1,5 @@
 import argparse
+import ast
 from collections import namedtuple
 
 from .formatters import format_choices
@@ -92,8 +93,8 @@ class StoreIdKwargs(argparse.Action):
             if '=' in kv:
                 key, val = kv.split('=')
                 try:
-                    val = eval(val, {}, {})  # disallow local, global vars
-                except NameError:
+                    val = ast.literal_eval(val)
+                except (SyntaxError, ValueError):
                     if not self.default_as_string:
                         raise
                     # default as string if can't eval

--- a/yoctol_argparse/actions.py
+++ b/yoctol_argparse/actions.py
@@ -40,11 +40,13 @@ class StoreIdKwargs(argparse.Action):
             id_choices,
             split_token=',',
             use_bool_abbreviation=True,
+            default_as_string=True,
             **kwargs,
         ):
         super().__init__(nargs='+', **kwargs)
         self.id_choices = id_choices
         self.split_token = split_token
+        self.default_as_string = default_as_string
         self.use_bool_abbreviation = use_bool_abbreviation
         self.metavar = (format_choices(id_choices), f'KEY1=VALUE1{split_token}KEY2=VALUE2')
 
@@ -86,7 +88,12 @@ class StoreIdKwargs(argparse.Action):
         for kv in kvs:
             if '=' in kv:
                 key, val = kv.split('=')
-                val = eval(val, {}, {})  # disallow local, global vars
+                try:
+                    val = eval(val, {}, {})  # disallow local, global vars
+                except NameError:
+                    if not self.default_as_string:
+                        raise
+                    # default as string if can't eval
             elif self.use_bool_abbreviation:
                 key, val = kv, True
             else:

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -57,12 +57,16 @@ class TestStoreIdKwargs:
             ('a', {'I': 1, 'F1': 1., 'F2': 1e-4, 'F3': -1e-4}),
         ],
         [
-            'main.py --foo a B1=False,B2=True,B3',
-            ('a', {'B1': False, 'B2': True, 'B3': True}),
+            'main.py --foo a B1=False,B2=True,B3,N=None',
+            ('a', {'B1': False, 'B2': True, 'B3': True, 'N': None}),
         ],
         [
-            'main.py --foo a NONE=None,FUNC=max,S=s',
-            StoreIdKwargs.IdKwargsPair('a', {'NONE': None, 'FUNC': max, 'S': 's'}),
+            'main.py --foo a S1=s,S2="s",S3=\'s\'',
+            ('a', {'S1': 's', 'S2': 's', 'S3': 's'}),
+        ],
+        [
+            'main.py --foo a 1=open,2=exit,3=exec,4=import,5=OSError',  # no builtins allowed
+            ('a', {'1': 'open', '2': 'exit', '3': 'exec', '4': 'import', '5': 'OSError'}),
         ],
     ])
     def test_store(self, yoctol_parser, arg_string, expected_output):

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -54,7 +54,7 @@ class TestStoreIdKwargs:
         ['main.py --foo a', ('a', {})],
         [
             'main.py --foo a I=1,F1=1.,F2=1e-4,F3=-1e-4',
-            ('a', {'I': 1, 'F1': 1., 'F2': 1e-4, 'F3': -1e-4})
+            ('a', {'I': 1, 'F1': 1., 'F2': 1e-4, 'F3': -1e-4}),
         ],
         [
             'main.py --foo a B1=False,B2=True,B3',
@@ -62,7 +62,7 @@ class TestStoreIdKwargs:
         ],
         [
             'main.py --foo a NONE=None,FUNC=max,S=s',
-            ('a', {'NONE': None, 'FUNC': max, 'S': 's'}),
+            StoreIdKwargs.IdKwargsPair('a', {'NONE': None, 'FUNC': max, 'S': 's'}),
         ],
     ])
     def test_store(self, yoctol_parser, arg_string, expected_output):

--- a/yoctol_argparse/tests/test_actions.py
+++ b/yoctol_argparse/tests/test_actions.py
@@ -51,8 +51,19 @@ class TestStoreIdKwargs:
         return parser
 
     @pytest.mark.parametrize('arg_string, expected_output', [
-        ('main.py --foo a', ('a', {})),
-        ('main.py --foo a x=1,y=False,z,w="w"', ('a', {'x': 1, 'y': False, 'z': True, 'w': 'w'})),
+        ['main.py --foo a', ('a', {})],
+        [
+            'main.py --foo a I=1,F1=1.,F2=1e-4,F3=-1e-4',
+            ('a', {'I': 1, 'F1': 1., 'F2': 1e-4, 'F3': -1e-4})
+        ],
+        [
+            'main.py --foo a B1=False,B2=True,B3',
+            ('a', {'B1': False, 'B2': True, 'B3': True}),
+        ],
+        [
+            'main.py --foo a NONE=None,FUNC=max,S=s',
+            ('a', {'NONE': None, 'FUNC': max, 'S': 's'}),
+        ],
     ])
     def test_store(self, yoctol_parser, arg_string, expected_output):
         with patch('sys.argv', arg_string.split(' ')):
@@ -65,7 +76,6 @@ class TestStoreIdKwargs:
         pytest.param('main.py --foo c 1', id='invalid_choice'),
         pytest.param('main.py --foo a x=1=y', id='invalid_format_='),
         pytest.param('main.py --foo a x=1+y=y', id='invalid_format_split'),
-        pytest.param('main.py --foo a x=1,y=y', id='invalid_value'),
         pytest.param('main.py --foo a x=1,x=2', id='duplicated_key'),
     ])
     def test_raise_invalid_arg(self, yoctol_parser, invalid_arg):


### PR DESCRIPTION
1. parse argv 的時候會把 ' 符號去掉 (不知道是只有 python 還是 UNIX 都是)
所以直接讓 eval 失敗的都當 string
2. 讓輸出變成 namedtuple，可以用 args.xxx.id, args.xxx.kwargs 來取
