### PR TITLE
Nested namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ ENV/
 
 dump.rdb
 .vscode/
+
+# Local test file
+tmp/

--- a/examples/nested_dest.py
+++ b/examples/nested_dest.py
@@ -1,0 +1,23 @@
+from yoctol_argparse import YoctolArgumentParser
+
+parser = YoctolArgumentParser()
+
+parser.add_argument(
+    '--exercise_type',
+    dest='exercise.type',
+    choices=['squat', 'bench', 'deadlift'],
+)
+parser.add_argument(
+    '--exercise_sets',
+    dest='exercise.volume.sets',
+    type=int,
+)
+parser.add_argument(
+    '--exercise_reps',
+    dest='exercise.volume.reps',
+    type=int,
+)
+
+
+parser.parse_args('--exercise_type bench --exercise_sets 5 --exercise_reps 10'.split())
+# = NestedNamespace(exercise=NestedNamespace(type='bench', volume=NestedNamespace(reps=10, sets=5)))

--- a/yoctol_argparse/__init__.py
+++ b/yoctol_argparse/__init__.py
@@ -8,6 +8,7 @@ from .__version__ import (
 from .actions import IdValuePair, IdKwargs
 from .formatters import YoctolFormatter
 from .parser import YoctolArgumentParser
+from .namespace import NestedNamespace
 from .types import (
     int_in_range,
     float_in_range,

--- a/yoctol_argparse/namespace.py
+++ b/yoctol_argparse/namespace.py
@@ -1,0 +1,32 @@
+from argparse import Namespace
+
+
+class NestedNamespace(Namespace):
+
+    def __setattr__(self, name: str, value):
+        names = self._split_first_dot(name)
+        if len(names) == 2:
+            attr_name, rest = names
+            if self.__contains__(attr_name):
+                sub_namespace = self.__getattribute__(attr_name)
+            else:
+                sub_namespace = self.__class__()
+                super().__setattr__(attr_name, sub_namespace)
+            setattr(sub_namespace, rest, value)
+        else:
+            super().__setattr__(name, value)
+
+    def __getattr__(self, name):
+        names = self._split_first_dot(name)
+        if len(names) == 2:
+            attr_name, rest = names
+            return super().__getattribute__(attr_name).__getattr__(rest)
+        else:
+            return super().__getattribute__(name)
+
+    @staticmethod
+    def _split_first_dot(string):
+        lst = string.split('.', maxsplit=1)
+        if not all(lst):
+            raise ValueError(f"invalid name: {string}")
+        return lst

--- a/yoctol_argparse/parser.py
+++ b/yoctol_argparse/parser.py
@@ -1,6 +1,7 @@
 import argparse
 
 from .formatters import YoctolFormatter
+from .namespace import NestedNamespace
 
 
 class YoctolArgumentParser(argparse.ArgumentParser):
@@ -34,3 +35,8 @@ class YoctolArgumentParser(argparse.ArgumentParser):
             add_help=add_help,
             allow_abbrev=allow_abbrev,
         )
+
+    def parse_known_args(self, args=None, namespace=None):
+        if namespace is None:
+            namespace = NestedNamespace()
+        return super().parse_known_args(args, namespace)

--- a/yoctol_argparse/tests/test_namespace.py
+++ b/yoctol_argparse/tests/test_namespace.py
@@ -5,14 +5,14 @@ from ..namespace import NestedNamespace
 
 def test_successfully_setattr():
     args = NestedNamespace()
-    setattr(args, 'a.b.c', 1)
-    setattr(args, 'a.b.d', 2)
+    setattr(args, 'a.b.c', 1)  # noqa
+    setattr(args, 'a.b.d', 2)  # noqa
     assert isinstance(args.a, NestedNamespace)
     assert isinstance(args.a.b, NestedNamespace)
-    assert args.a.b.c == getattr(args, 'a.b.c') == 1
-    assert args.a.b.d == getattr(args, 'a.b.d') == 2
+    assert args.a.b.c == getattr(args, 'a.b.c') == 1  # noqa
+    assert args.a.b.d == getattr(args, 'a.b.d') == 2  # noqa
 
-    setattr(args, 'e', 2)
+    setattr(args, 'e', 2)  # noqa
     assert args.e == 2
 
 
@@ -22,7 +22,7 @@ def test_raise_error():
         args.f
 
     with pytest.raises(ValueError):
-        setattr(args, 'a.', 1)
+        setattr(args, 'a.', 1)  # noqa
 
     with pytest.raises(ValueError):
-        setattr(args, '..a', 1)
+        setattr(args, '..a', 1)  # noqa

--- a/yoctol_argparse/tests/test_namespace.py
+++ b/yoctol_argparse/tests/test_namespace.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ..namespace import NestedNamespace
+
+
+def test_successfully_setattr():
+    args = NestedNamespace()
+    setattr(args, 'a.b.c', 1)
+    setattr(args, 'a.b.d', 2)
+    assert isinstance(args.a, NestedNamespace)
+    assert isinstance(args.a.b, NestedNamespace)
+    assert args.a.b.c == getattr(args, 'a.b.c') == 1
+    assert args.a.b.d == getattr(args, 'a.b.d') == 2
+
+    setattr(args, 'e', 2)
+    assert args.e == 2
+
+
+def test_raise_error():
+    args = NestedNamespace()
+    with pytest.raises(AttributeError):
+        args.f
+
+    with pytest.raises(ValueError):
+        setattr(args, 'a.', 1)
+
+    with pytest.raises(ValueError):
+        setattr(args, '..a', 1)


### PR DESCRIPTION
add_argument 的 dest 參數支援像是 `a.b.c` 的語法
nested 的 set attribute
詳見 examples/nested_dest.py
